### PR TITLE
修复两个API接口的BUG, 请合并一下

### DIFF
--- a/futuquant/quote/quote_query.py
+++ b/futuquant/quote/quote_query.py
@@ -1080,7 +1080,7 @@ class OrderBookQuery:
         raw_order_book_bid = rsp_pb.s2c.orderBookBidList
 
         order_book = {}
-        order_book['code'] = merge_qot_mkt_stock_str(rsp_pb.s2c.security.market, rsp_pb.s2c.security.code),
+        order_book['code'] = merge_qot_mkt_stock_str(rsp_pb.s2c.security.market, rsp_pb.s2c.security.code)
         order_book['Bid'] = []
         order_book['Ask'] = []
 

--- a/futuquant/quote/quote_response_handler.py
+++ b/futuquant/quote/quote_response_handler.py
@@ -284,7 +284,7 @@ class BrokerHandlerBase(RspHandlerBase):
             bid_frame_table = pd.DataFrame(bid_content, columns=bid_list)
             ask_frame_table = pd.DataFrame(ask_content, columns=ask_list)
 
-            return RET_OK, stock_code, [bid_frame_table, ask_frame_table]
+            return RET_OK, (stock_code, [bid_frame_table, ask_frame_table])
 
 
 class KeepAliveHandlerBase(RspHandlerBase):


### PR DESCRIPTION
quote_query.py OrderBookQuery::unpack_rsp order_book['code'] 拼接股票代码错误的添加了一个逗号在股票代码后面
quote_response_handler.py BrokerHandlerBase::on_recv_rsp 返回时错误的返回了三个结果