### PR TITLE
Exit network manager thread while main thread is exiting

### DIFF
--- a/futuquant/common/network_manager.py
+++ b/futuquant/common/network_manager.py
@@ -191,6 +191,7 @@ class NetManager:
         if self._thread is not None:
             return
         self._thread = threading.Thread(target=self._thread_func)
+        self._thread.setDaemon(True)
         self._thread.start()
 
     def stop(self):


### PR DESCRIPTION
复现：

在 ipython 终端中

```python
In [1]: from futuquant import *
   ...: quote_ctx = OpenQuoteContext(host='127.0.0.1', port=11111)
```

随后按 Ctrl-C 进程无法退出，除非再按一次，然后会出现报错：

```
^CException ignored in: <module 'threading' from '/home/stochasticprocess/.pyenv/versions/3.6.5/lib/python3.6/threading.py'>
Traceback (most recent call last):
  File "/home/stochasticprocess/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 1294, in _shutdown
    t.join()
  File "/home/stochasticprocess/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 1056, in join
    self._wait_for_tstate_lock()
  File "/home/stochasticprocess/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 1072, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
KeyboardInterrupt
``` 

这个问题还有个解决办法是退出前调用 `quote_ctx.close()`, 但这种方式在集成到Flask的过程中没办法做。我觉得这个PR的解决方式比较好，把 network manager 变成 daemon thread, 这样当主线程退出时，它不会block住主线程退出，而是随之一起退出。